### PR TITLE
Fixing swig-3 command not found with Ubuntu 20.04 LTS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all:
 	cp -r $(SDK_PATH)/include ./include
 	wget http://tinyurl.com/leap-i-patch -O Leap.i.diff
 	patch -p0 < Leap.i.diff
-	swig-3 -c++ -python -o LeapPython.cpp -interface LeapPython ./include/Leap.i
+	swig3.0 -c++ -python -o LeapPython.cpp -interface LeapPython ./include/Leap.i
 	g++ -fPIC -I/usr/include/python$(PYTHON3_VERSION)m -I/usr/include/python$(PYTHON3_VERSION) -I$(SDK_PATH)/include LeapPython.cpp $(SDK_PATH)/lib/$(ARCH)/libLeap.so -shared -o LeapPython.so
 
 clean:


### PR DESCRIPTION
Hi,
The command swig for version 3 seem to not be working with the original syntax(command not found )
I've managed to get it to work with this syntax swig3.0